### PR TITLE
Fix Privy init before wallet create

### DIFF
--- a/dist/NFC Passkey.3c14d121.js
+++ b/dist/NFC Passkey.3c14d121.js
@@ -1,3 +1,10 @@
+        privy = new Privy({
+            appId: privyAppId,
+            storage: localStorageAdapter // Use the custom adapter
+        });
+        console.log('Privy SDK initialized with custom storage adapter.');
+        await privy.initialize();
+        console.log('Privy iframe ready. Inspecting Privy object:', privy);
             console.log('Attempting privy.auth.guest.create()...');
             if (privy.auth && privy.auth.guest && typeof privy.auth.guest.create === 'function') {
                 const { user: guestUser } = await privy.auth.guest.create();

--- a/script.js
+++ b/script.js
@@ -3,7 +3,7 @@ import Privy from '@privy-io/js-sdk-core';
 // Add PrivyClient if you were to use the SDK directly
 // For now, we simulate the Privy interaction.
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     const claimButton = document.getElementById('claimButton');
     const statusMessage = document.getElementById('statusMessage');
     const privyAppId = 'cmb9z52y600o1ky0m78whsb08'; // Your Privy App ID
@@ -54,12 +54,13 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     try {
-        privy = new Privy({ 
+        privy = new Privy({
             appId: privyAppId,
             storage: localStorageAdapter // Use the custom adapter
         });
         console.log('Privy SDK initialized with custom storage adapter.');
-        console.log('Inspecting Privy object:', privy); // Log the privy object for inspection
+        await privy.initialize();
+        console.log('Privy iframe ready. Inspecting Privy object:', privy);
     } catch (error) {
         statusMessage.textContent = 'Error: Account system components failed to initialize. Please refresh.';
         claimButton.disabled = true;


### PR DESCRIPTION
## Summary
- wait for Privy iframe initialization before calling `embeddedWallet.create`
- rebuild dist JS bundle snippet

## Testing
- `npm test` *(fails: Error: no test specified)*